### PR TITLE
Use default Shopware-way to update order payment status

### DIFF
--- a/Components/Services/OrderDataService.php
+++ b/Components/Services/OrderDataService.php
@@ -40,30 +40,6 @@ class OrderDataService
     }
 
     /**
-     * @param string $orderNumber
-     * @param int    $paymentStatusId
-     *
-     * @return bool
-     */
-    public function applyPaymentStatus($orderNumber, $paymentStatusId)
-    {
-        $builder = $this->dbalConnection->createQueryBuilder();
-        $builder->update('s_order', 'o')
-            ->set('o.cleared', ':paymentStatus')
-            ->where('o.ordernumber = :orderNumber')
-            ->setParameters([
-                ':orderNumber' => $orderNumber,
-                ':paymentStatus' => $paymentStatusId,
-            ]);
-
-        if ($paymentStatusId === PaymentStatus::PAYMENT_STATUS_APPROVED) {
-            $builder->set('o.cleareddate', 'NOW()');
-        }
-
-        return $builder->execute() === 1;
-    }
-
-    /**
      * @param int    $orderNumber
      * @param string $transactionId
      *

--- a/Controllers/Frontend/PaypalUnified.php
+++ b/Controllers/Frontend/PaypalUnified.php
@@ -346,22 +346,29 @@ class Shopware_Controllers_Frontend_PaypalUnified extends \Shopware_Controllers_
         $message = null;
         $name = null;
 
-        if ($exception && $this->settingsService->hasSettings() && $this->settingsService->get('display_errors')) {
+        if ($exception) {
             /** @var ExceptionHandlerServiceInterface $exceptionHandler */
             $exceptionHandler = $this->get('paypal_unified.exception_handler_service');
-
             $error = $exceptionHandler->handle($exception, 'process checkout');
-            $message = $error->getMessage();
-            $name = $error->getName();
+
+            if ($this->settingsService->hasSettings() && $this->settingsService->get('display_errors')) {
+                $message = $error->getMessage();
+                $name = $error->getName();
+            }
         }
 
-        $this->redirect([
+        $redirectData = [
             'controller' => 'checkout',
             'action' => 'shippingPayment',
             'paypal_unified_error_code' => $code,
-            'paypal_unified_error_name' => $name,
-            'paypal_unified_error_message' => $message,
-        ]);
+        ];
+
+        if ($name !== null) {
+            $redirectData['paypal_unified_error_name'] = $name;
+            $redirectData['paypal_unified_error_message'] = $message;
+        }
+
+        $this->redirect($redirectData);
     }
 
     /**

--- a/Controllers/Frontend/PaypalUnified.php
+++ b/Controllers/Frontend/PaypalUnified.php
@@ -5,6 +5,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+use Doctrine\DBAL\Connection;
 use Shopware\Components\HttpClient\RequestException;
 use SwagPaymentPayPalUnified\Components\ErrorCodes;
 use SwagPaymentPayPalUnified\Components\ExceptionHandlerServiceInterface;
@@ -235,22 +236,18 @@ class Shopware_Controllers_Frontend_PaypalUnified extends \Shopware_Controllers_
             /** @var RelatedResource $responseSale */
             $responseSale = $response->getTransactions()->getRelatedResources()->getResources()[0];
 
-            // apply the payment status if its completed by PayPal
-            $paymentState = $responseSale->getState();
-            if ($paymentState === PaymentStatus::PAYMENT_COMPLETED &&
-                !$orderDataService->applyPaymentStatus($orderNumber, PaymentStatus::PAYMENT_STATUS_APPROVED)
-            ) {
-                $this->handleError(ErrorCodes::NO_ORDER_TO_PROCESS);
-
-                return;
-            }
-
             //Use TXN-ID instead of the PaymentId
             $saleId = $responseSale->getId();
             if (!$orderDataService->applyTransactionId($orderNumber, $saleId)) {
                 $this->handleError(ErrorCodes::NO_ORDER_TO_PROCESS);
 
                 return;
+            }
+
+            // apply the payment status if its completed by PayPal
+            $paymentState = $responseSale->getState();
+            if ($paymentState === PaymentStatus::PAYMENT_COMPLETED) {
+                $this->markOrderAsPayed($saleId, $paymentId);
             }
 
             // Save payment instructions from PayPal to database.
@@ -283,6 +280,30 @@ class Shopware_Controllers_Frontend_PaypalUnified extends \Shopware_Controllers_
         } catch (\Exception $exception) {
             $this->handleError(ErrorCodes::UNKNOWN, $exception);
         }
+    }
+
+    /**
+     * @param string $saleId
+     * @param string $paymentId
+     */
+    private function markOrderAsPayed($saleId, $paymentId)
+    {
+        $this->savePaymentStatus($saleId, $paymentId, PaymentStatus::PAYMENT_STATUS_APPROVED, false);
+
+        /** @var Connection $dbalConnection */
+        $dbalConnection = $this->get('dbal_connection');
+        $builder = $dbalConnection->createQueryBuilder();
+        $builder
+            ->update('s_order', 'o')
+            ->set('o.cleareddate', 'NOW()')
+            ->where('o.transactionID = :transactionId')
+            ->andWhere('o.temporaryID = :temporaryId')
+            ->setParameters([
+                ':transactionId' => $saleId,
+                ':temporaryId' => $paymentId,
+            ]);
+
+        $builder->execute();
     }
 
     /**

--- a/Controllers/Widgets/PaypalUnifiedExpressCheckout.php
+++ b/Controllers/Widgets/PaypalUnifiedExpressCheckout.php
@@ -183,22 +183,29 @@ class Shopware_Controllers_Widgets_PaypalUnifiedExpressCheckout extends \Enlight
         $message = null;
         $name = null;
 
-        if ($exception && $this->settingsService->hasSettings() && $this->settingsService->get('display_errors')) {
+        if ($exception) {
             /** @var ExceptionHandlerServiceInterface $exceptionHandler */
             $exceptionHandler = $this->get('paypal_unified.exception_handler_service');
-
             $error = $exceptionHandler->handle($exception, 'process express-checkout');
-            $message = $error->getMessage();
-            $name = $error->getName();
+
+            if ($this->settingsService->hasSettings() && $this->settingsService->get('display_errors')) {
+                $message = $error->getMessage();
+                $name = $error->getName();
+            }
         }
 
-        $this->redirect([
+        $redirectData = [
             'controller' => 'checkout',
             'action' => 'shippingPayment',
             'expressCheckout' => true,
             'paypal_unified_error_code' => $code,
-            'paypal_unified_error_name' => $name,
-            'paypal_unified_error_message' => $message,
-        ]);
+        ];
+
+        if ($name !== null) {
+            $redirectData['paypal_unified_error_name'] = $name;
+            $redirectData['paypal_unified_error_message'] = $message;
+        }
+
+        $this->redirect($redirectData);
     }
 }

--- a/Resources/services/subscribers.xml
+++ b/Resources/services/subscribers.xml
@@ -69,6 +69,7 @@
             <argument type="service" id="paypal_unified.exception_handler_service"/>
             <argument type="service" id="dbal_connection"/>
             <argument type="service" id="paypal_unified.client_service"/>
+            <argument type="service" id="paypal_unified.dependency_provider"/>
             <tag name="shopware.event_subscriber"/>
         </service>
 
@@ -84,6 +85,7 @@
                  class="SwagPaymentPayPalUnified\Subscriber\InContext">
             <argument type="service" id="dbal_connection"/>
             <argument type="service" id="paypal_unified.settings_service"/>
+            <argument type="service" id="paypal_unified.dependency_provider"/>
             <tag name="shopware.event_subscriber"/>
         </service>
 

--- a/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.express-checkout-button-in-context.js
+++ b/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.express-checkout-button-in-context.js
@@ -66,6 +66,13 @@
             tagline: false,
 
             /**
+             * The language ISO (ISO_639) for the payment wall.
+             *
+             * @type string
+             */
+            paypalLanguage: 'en_US',
+
+            /**
              * A boolean indicating if the current page is an product detail page.
              *
              * @type boolean
@@ -152,6 +159,8 @@
                     color: me.opts.color,
                     tagline: me.opts.tagline
                 },
+
+                locale: me.opts.paypalLanguage,
 
                 /**
                  * listener for the button

--- a/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.express-checkout-button.js
+++ b/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.express-checkout-button.js
@@ -66,6 +66,13 @@
             tagline: false,
 
             /**
+             * The language ISO (ISO_639) for the payment wall.
+             *
+             * @type string
+             */
+            paypalLanguage: 'en_US',
+
+            /**
              * A boolean indicating if the current page is an product detail page.
              *
              * @type boolean
@@ -151,6 +158,8 @@
                     color: me.opts.color,
                     tagline: me.opts.tagline
                 },
+
+                locale: me.opts.paypalLanguage,
 
                 /**
                  * listener for the button

--- a/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.in-context-checkout.js
+++ b/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.in-context-checkout.js
@@ -78,6 +78,13 @@
             color: 'gold',
 
             /**
+             * The language ISO (ISO_639) for the payment wall.
+             *
+             * @type string
+             */
+            paypalLanguage: 'en_US',
+
+            /**
              * selector for the checkout confirm form element
              *
              * @type string
@@ -162,6 +169,8 @@
                     shape: me.opts.shape,
                     color: me.opts.color
                 },
+
+                locale: me.opts.paypalLanguage,
 
                 /**
                  * listener for custom validations

--- a/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.payment-wall.js
+++ b/Resources/views/frontend/_public/src/js/jquery.swag-paypal-unified.payment-wall.js
@@ -133,9 +133,9 @@
              * Third party methods which will be shown in the payment wall iFrame
              * formatted as JSON string, will be decoded on calling `applyDataAttributes`
              *
-             * @type string
+             * @type Array
              */
-            thirdPartyPaymentMethods: ''
+            thirdPartyPaymentMethods: []
         },
 
         /**

--- a/Resources/views/frontend/paypal_unified/express_checkout/button_cart.tpl
+++ b/Resources/views/frontend/paypal_unified/express_checkout/button_cart.tpl
@@ -12,6 +12,7 @@
                  data-color="{$paypalUnifiedEcButtonStyleColor}"
                  data-shape="{$paypalUnifiedEcButtonStyleShape}"
                  data-size="{$paypalUnifiedEcButtonStyleSize}"
+                 data-paypalLanguage="{$paypalUnifiedLanguageIso}"
                  data-cart="true"
                 {block name='paypal_unified_ec_button_container_cart_data'}{/block}>
             </div>

--- a/Resources/views/frontend/paypal_unified/express_checkout/button_detail.tpl
+++ b/Resources/views/frontend/paypal_unified/express_checkout/button_detail.tpl
@@ -12,6 +12,7 @@
                  data-color="{$paypalUnifiedEcButtonStyleColor}"
                  data-shape="{$paypalUnifiedEcButtonStyleShape}"
                  data-size="{$paypalUnifiedEcButtonStyleSize}"
+                 data-paypalLanguage="{$paypalUnifiedLanguageIso}"
                  data-detailPage="true"
                 {block name='paypal_unified_ec_button_container_detail_data'}{/block}>
             </div>

--- a/Resources/views/frontend/paypal_unified/in_context/button.tpl
+++ b/Resources/views/frontend/paypal_unified/in_context/button.tpl
@@ -8,6 +8,7 @@
                  data-color="{$paypalUnifiedEcButtonStyleColor}"
                  data-shape="{$paypalUnifiedEcButtonStyleShape}"
                  data-size="{$paypalUnifiedEcButtonStyleSize}"
+                 data-paypalLanguage="{$paypalUnifiedLanguageIso}"
                 {block name='frontend_checkout_confirm_paypal_unified_in_context_button_data'}{/block}>
             </div>
         {/block}

--- a/Resources/views/frontend/paypal_unified/plus/checkout/payment_wall_premiums.tpl
+++ b/Resources/views/frontend/paypal_unified/plus/checkout/payment_wall_premiums.tpl
@@ -4,7 +4,7 @@
             {* Unified payment wall plugin *}
             <div class="is--hidden"
                  data-paypalPaymentWall="true"
-                 data-paypalLanguage="{$paypalUnifiedPlusLanguageIso}"
+                 data-paypalLanguage="{$paypalUnifiedLanguageIso}"
                  data-paypalApprovalUrl="{$paypalUnifiedApprovalUrl}"
                  data-paypalCountryIso="{$sUserData.additional.country.countryiso}"
                  data-paypalMode="{if $paypalUnifiedModeSandbox}sandbox{else}live{/if}">

--- a/Resources/views/frontend/paypal_unified/plus/checkout/payment_wall_shipping_payment.tpl
+++ b/Resources/views/frontend/paypal_unified/plus/checkout/payment_wall_shipping_payment.tpl
@@ -2,7 +2,7 @@
     {* Payment wall plugin *}
     <div class="is--hidden"
          data-paypaLPaymentWall="true"
-         data-paypalLanguage="{$paypalUnifiedPlusLanguageIso}"
+         data-paypalLanguage="{$paypalUnifiedLanguageIso}"
          data-paypalApprovalUrl="{$paypalUnifiedApprovalUrl}"
          data-paypalCountryIso="{$sUserData.additional.country.countryiso}"
          data-paypalMode="{if $paypalUnifiedModeSandbox}sandbox{else}live{/if}"

--- a/Subscriber/Plus.php
+++ b/Subscriber/Plus.php
@@ -321,7 +321,7 @@ class Plus implements SubscriberInterface
         $view->assign('paypalUnifiedModeSandbox', $this->settingsService->get('sandbox'));
         $view->assign('paypalUnifiedRemotePaymentId', $paymentStruct->getId());
         $view->assign('paypalUnifiedApprovalUrl', $paymentStruct->getLinks()[1]->getHref());
-        $view->assign('paypalUnifiedPlusLanguageIso', $this->getPaymentWallLanguage());
+        $view->assign('paypalUnifiedLanguageIso', $this->getPaymentWallLanguage());
     }
 
     /**
@@ -341,7 +341,7 @@ class Plus implements SubscriberInterface
         $view->assign('paypalUnifiedPaymentId', $this->paymentMethodProvider->getPaymentId($this->connection));
         $view->assign('paypalUnifiedRemotePaymentId', $paymentStruct->getId());
         $view->assign('paypalUnifiedApprovalUrl', $paymentStruct->getLinks()[1]->getHref());
-        $view->assign('paypalUnifiedPlusLanguageIso', $this->getPaymentWallLanguage());
+        $view->assign('paypalUnifiedLanguageIso', $this->getPaymentWallLanguage());
 
         //Store the paymentID in the session to indicate that
         //the payment has already been created and can be used on the confirm page.

--- a/Tests/Functional/Components/Services/OrderDataServiceTest.php
+++ b/Tests/Functional/Components/Services/OrderDataServiceTest.php
@@ -34,33 +34,6 @@ class OrderDataServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(OrderDataService::class, $orderDataService);
     }
 
-    public function test_apply_order_status_without_existing_order_returns_false()
-    {
-        $orderDataService = $this->getOrderDataService();
-
-        $this->assertFalse($orderDataService->applyPaymentStatus('WRONG_ORDER_NUMBER', self::PAYMENT_STATUS_APPROVED));
-    }
-
-    public function test_should_update_order_status()
-    {
-        $orderDataService = $this->getOrderDataService();
-
-        $orderDataService->applyPaymentStatus(self::ORDER_NUMBER, self::PAYMENT_STATUS_APPROVED);
-
-        /** @var Connection $dbalConnection */
-        $dbalConnection = Shopware()->Container()->get('dbal_connection');
-        $updatedOrder = $dbalConnection->executeQuery('SELECT * FROM s_order WHERE ordernumber="' . self::ORDER_NUMBER . '"')->fetchAll();
-
-        $this->assertEquals(self::PAYMENT_STATUS_APPROVED, $updatedOrder[0]['cleared']);
-    }
-
-    public function test_apply_transaction_id_without_existing_order_returns_false()
-    {
-        $orderDataService = $this->getOrderDataService();
-
-        $this->assertFalse($orderDataService->applyPaymentStatus('WRONG_ORDER_NUMBER', self::PAYMENT_STATUS_APPROVED));
-    }
-
     public function test_should_update_transaction_id()
     {
         $orderDataService = $this->getOrderDataService();

--- a/Tests/Functional/Subscriber/ExpressCheckoutSubscriberTest.php
+++ b/Tests/Functional/Subscriber/ExpressCheckoutSubscriberTest.php
@@ -576,7 +576,8 @@ class ExpressCheckoutSubscriberTest extends \PHPUnit_Framework_TestCase
             Shopware()->Container()->get('paypal_unified.payment_builder_service'),
             Shopware()->Container()->get('paypal_unified.exception_handler_service'),
             Shopware()->Container()->get('dbal_connection'),
-            Shopware()->Container()->get('paypal_unified.client_service')
+            Shopware()->Container()->get('paypal_unified.client_service'),
+            Shopware()->Container()->get('paypal_unified.dependency_provider')
         );
     }
 }

--- a/Tests/Functional/Subscriber/InContextSubscriberTest.php
+++ b/Tests/Functional/Subscriber/InContextSubscriberTest.php
@@ -259,7 +259,8 @@ class InContextSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         return new InContext(
             Shopware()->Container()->get('dbal_connection'),
-            Shopware()->Container()->get('paypal_unified.settings_service')
+            Shopware()->Container()->get('paypal_unified.settings_service'),
+            Shopware()->Container()->get('paypal_unified.dependency_provider')
         );
     }
 }

--- a/Tests/Functional/Subscriber/PlusSubscriberTest.php
+++ b/Tests/Functional/Subscriber/PlusSubscriberTest.php
@@ -387,7 +387,7 @@ class PlusSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('PAY-9HW62735H82101921LLK3D4I', $viewAssignments['paypalUnifiedRemotePaymentId']);
         $this->assertEquals('https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-49W9096312907153R', $viewAssignments['paypalUnifiedApprovalUrl']);
-        $this->assertEquals('de_DE', $viewAssignments['paypalUnifiedPlusLanguageIso']);
+        $this->assertEquals('de_DE', $viewAssignments['paypalUnifiedLanguageIso']);
     }
 
     public function test_onPostDispatchSecure_handleConfirmDispatch_should_return_because_of_no_paymentStruct()
@@ -413,7 +413,7 @@ class PlusSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($viewAssignments['paypalUnifiedRemotePaymentId']);
         $this->assertNull($viewAssignments['paypalUnifiedApprovalUrl']);
-        $this->assertNull($viewAssignments['paypalUnifiedPlusLanguageIso']);
+        $this->assertNull($viewAssignments['paypalUnifiedLanguageIso']);
     }
 
     public function test_onPostDispatchSecure_handleConfirmDispatch_return_came_from_step_two()


### PR DESCRIPTION
### 1. Why is this change necessary?
The **PayPal Unified** plugin currently sets the payment status of an order directly via a SQL query. Therefore other plugins cannot track changes of the payment status because this does not triggers any of the usual hooks (e.g. hooks of the methods in the doctrine model or `sOrder` class).

Also no order status history entry is written.

### 2. What does this change do, exactly?
This PR changes the `returnAction` of the `Shopware_Controllers_Frontend_PaypalUnified` controller to use the method `\Shopware_Controllers_Frontend_Payment::savePaymentStatus` to save the order payment status. This method is part of SW and can easily be hooked by any plugins independently of which payment provider is used.

The method `\SwagPaymentPayPalUnified\Components\Services\OrderDataService::applyPaymentStatus` is removed. Please note, that this is a backward incompatiple change, but it is necessary.